### PR TITLE
Support named pipe connection on windows platform.

### DIFF
--- a/pkg/ovsdb/client.go
+++ b/pkg/ovsdb/client.go
@@ -190,7 +190,9 @@ func Dial(addressList [][]string, initialize func(*OVSDB) error, options map[str
 
 				conn, err = tls.Dial("tcp", address, cfg)
 			} else {
-				conn, err = net.Dial(network, address)
+				// DialNet is platform dependent. On windows platform, the "named pipe" connection is supported
+				// and the corresponding network name is "winpipe".
+				conn, err = DialNet(network, address)
 			}
 
 			if err != nil {

--- a/pkg/ovsdb/dial.go
+++ b/pkg/ovsdb/dial.go
@@ -1,0 +1,9 @@
+// +build linux darwin
+
+package ovsdb
+
+import "net"
+
+func DialNet(network, address string) (net.Conn, error) {
+	return net.Dial(network, address)
+}

--- a/pkg/ovsdb/dial_windows.go
+++ b/pkg/ovsdb/dial_windows.go
@@ -1,0 +1,14 @@
+package ovsdb
+
+import (
+	"github.com/Microsoft/go-winio"
+	"net"
+)
+
+// DialNet supports connect to named pipe by specifying network as "winpipe".
+func DialNet(network, address string) (net.Conn, error) {
+	if network == "winpipe" {
+		return winio.DialPipe(address, nil)
+	}
+	return net.Dial(network, address)
+}

--- a/pkg/ovsdb/dial_windows_test.go
+++ b/pkg/ovsdb/dial_windows_test.go
@@ -1,0 +1,24 @@
+package ovsdb
+
+import (
+	"testing"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func TestPipeDialNet(t *testing.T) {
+	network := "winpipe"
+	address := `\\.\pipe\ovsdbclienttestpipe`
+	l, err := winio.ListenPipe(address, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	defer l.Close()
+	go func() {
+		_, err = l.Accept()
+	}()
+	_, err = DialNet(network, address)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
On windows platform, ovsdb-server listens on a named pipe by default.
This patch provide support to connect to ovsdb-server using windows
named pipe.